### PR TITLE
Workaround linker issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 FROM conanio/gcc13-ubuntu16.04
 
-COPY src /home/conan/cxx_template/src
-COPY CMakeLists.txt /home/conan/cxx_template
-COPY conanfile.py /home/conan/cxx_template
-COPY main.cxx /home/conan/cxx_template
-
-
 WORKDIR /home/conan/cxx_template
 
-RUN sudo chown -R conan /home/conan  && conan install . --output-folder=build --settings build_type=Release  --settings compiler.cppstd=gnu20 --build=missing
+COPY conanfile.py /home/conan/cxx_template
+RUN sudo chown -R conan /home/conan  \
+   && conan install . --output-folder=build --settings build_type=Release  --settings compiler.cppstd=gnu20 --build=missing
 
 WORKDIR /home/conan/cxx_template/build
+COPY src /home/conan/cxx_template/src
+COPY CMakeLists.txt /home/conan/cxx_template
+COPY main.cxx /home/conan/cxx_template
 
 RUN cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -D CMAKE_BUILD_TYPE=Release
 

--- a/main.cxx
+++ b/main.cxx
@@ -1,12 +1,23 @@
 #include "src/hello.hxx"
 #include <boost/asio.hpp>
 #include <boost/asio/experimental/awaitable_operators.hpp>
-int
-main ()
-{
-  using namespace boost::asio::experimental::awaitable_operators;
-  auto ioContext = boost::asio::io_context{};
-  boost::asio::ip::tcp::socket socket (ioContext);
-  auto test = socket.async_connect ({}, boost::asio::use_awaitable) && socket.async_connect ({}, boost::asio::use_awaitable);
-  abc ();
+
+struct my_token_t : boost::asio::use_awaitable_t<> { } static inline constexpr my_token;
+template <typename... Sigs>
+struct boost::asio::async_result<my_token_t, Sigs...> : async_result<use_awaitable_t<>, Sigs...> {};
+
+int main() {
+    namespace asio = boost::asio;
+    using asio::ip::tcp;
+    using namespace asio::experimental::awaitable_operators;
+
+    asio::io_context ioc;
+    tcp::socket      s(ioc);
+
+    auto token = my_token;
+    co_spawn(
+        ioc,
+        (s.async_connect({}, token) && s.async_connect({}, token)),
+        asio::detached);
+    abc();
 }

--- a/src/hello.cxx
+++ b/src/hello.cxx
@@ -3,11 +3,15 @@
 #include <boost/asio/experimental/awaitable_operators.hpp>
 
 boost::asio::awaitable<void> helloWorld() {
-  using namespace boost::asio::experimental::awaitable_operators;
-  auto ioContext = boost::asio::io_context{};
-  boost::asio::ip::tcp::socket socket(ioContext);
-  auto test = socket.async_connect({}, boost::asio::use_awaitable) &&
-              socket.async_connect({}, boost::asio::use_awaitable);
+    namespace asio = boost::asio;
+    using asio::ip::tcp;
+    using namespace asio::experimental::awaitable_operators;
+
+    tcp::socket s(co_await asio::this_coro::executor);
+    auto token = asio::use_awaitable;
+    co_await (s.async_connect({}, token) && s.async_connect({}, token));
+
+    co_return;
 }
 
 int abc() { return 42; }


### PR DESCRIPTION
from https://stackoverflow.com/questions/77959920/linker-error-defined-in-discarded-section-with-boost-asio-awaitable-operators

> 
> So, there are two key components:
> 
>  - two separate linker objects (the main program and the library) instantiate a set of template instances
>  - the one from the library is discarded because it is unused
> 
> Key to reproducing this is that the exact instantiations of deferred async operations match in both the main program and the library implementation details. This, to me, seems like most likely a compiler issue.
> 
> I've reworded the main/lib sources to remove a-typical things: 
>  - the coro lacked a return statement, anyways, so that was invoking [UB](https://en.wikipedia.org/wiki/Undefined_behavior))
>  - non of the parallel-group deferred operations where actually awaited, and I worried that somehow this caused more symbols to be discarded than otherwise, so I added those.
> 
> 
>  * File `main.cxx`
>    ```c++
>    #include "src/hello.hxx"
>    #include <boost/asio.hpp>
>    #include <boost/asio/experimental/awaitable_operators.hpp>
>    
>    int main() {
>        namespace asio = boost::asio;
>        using asio::ip::tcp;
>        using namespace asio::experimental::awaitable_operators;
>    
>        asio::io_context ioc;
>        tcp::socket      s(ioc);
>    
>        auto token = asio::use_awaitable;
>        co_spawn(
>            ioc,
>            (s.async_connect({}, token) && s.async_connect({}, token)),
>            asio::detached);
>        abc();
>    }
>    ```
> 
>  * File `src/hello.cxx`
>    ```c++
>    #include "hello.hxx"
>    #include <boost/asio.hpp>
>    #include <boost/asio/experimental/awaitable_operators.hpp>
>    
>    boost::asio::awaitable<void> helloWorld() {
>        namespace asio = boost::asio;
>        using asio::ip::tcp;
>        using namespace asio::experimental::awaitable_operators;
>    
>        tcp::socket s(co_await asio::this_coro::executor);
>        auto token = asio::use_awaitable;
>        co_await (s.async_connect({}, token) && s.async_connect({}, token));
>    
>        co_return;
>    }
>    
>    int abc() { return 42; }
>    ```
> 
> ## Veryifying the Hypothesis 
> 
> If you change the token in one of the two translation units to e.g.
> 
>     auto token = as_tuple(asio::use_awaitable);
> 
> the linker is satisfied
> 
> ## Workaround
> 
> Like I said, I think this likely is a compiler bug to do with c++20 coroutine machinery. However, since creating your own token does work around it, I'd consider duplicating the implementation:
> 
>     struct my_token_t : boost::asio::use_awaitable_t<> { } static inline constexpr my_token;
>     template <typename... Sigs>
>     struct boost::asio::async_result<my_token_t, Sigs...> : async_result<use_awaitable_t<>, Sigs...> {};
> 
> Now the conflict is avoided:
