### PR TITLE
Way simpler mitigation

### DIFF
--- a/src/hello.cxx
+++ b/src/hello.cxx
@@ -2,12 +2,13 @@
 #include <boost/asio.hpp>
 #include <boost/asio/experimental/awaitable_operators.hpp>
 
-boost::asio::awaitable<void> helloWorld() {
+static boost::asio::awaitable<void> helloWorld() {
   using namespace boost::asio::experimental::awaitable_operators;
   auto ioContext = boost::asio::io_context{};
   boost::asio::ip::tcp::socket socket(ioContext);
   auto test = socket.async_connect({}, boost::asio::use_awaitable) &&
               socket.async_connect({}, boost::asio::use_awaitable);
+  co_return;
 }
 
 int abc() { return 42; }


### PR DESCRIPTION
In relation to the first attempt #1 

Not even a workaround: you can avoid the conflicting symbols being emitted at all, by making them file-static. E.g. make `helloWorld` static or enclose it in an anonymous namespace.

This builds in your container.